### PR TITLE
Intellij 230 Maven workspace war-core-ext validation is invalid when the Gradle Workspace 72 window exists

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,15 +27,15 @@ You can install this using _Preferences > Plugins > Install plugin from disk... 
 
 - Create a Liferay Workspace Project from Start menu > click *Create New Project* or click *File* > *New* > *Project*
 
-- Choose *Liferay Workspace* from left list
+1. Choose *Liferay Workspace* from left list
 
-- Click *Next* button
+1. Click *Next* button
 
-- Type your Liferay Workspace *Project Name* and choose a *Project Location* or leave it default.
+1. Type your Liferay Workspace *Project Name* and choose a *Project Location* or leave it default.
 
-- Click *Finish* button and there will be one popup show up.
+1. Click *Finish* button and there will be one popup show up.
 
-- Click *OK* to finish
+1. Click *OK* to finish
 
 ### Liferay Server
 
@@ -43,23 +43,23 @@ You must have one Liferay Workspace Project to do the following steps:
 
 - Right click on the root of your Liferay Workspace Project
 
-- Click Liferay > InitBundle
+1. Click Liferay > InitBundle
 
-- Then the gradle will run *initBundle* task
+1. Then the gradle will run *initBundle* task
 
-- It will take several minutes to download the latest Liferay Server from remote if you don't have the local cache
+1. It will take several minutes to download the latest Liferay Server from remote if you don't have the local cache
 
-- Click *Edit configruration...* on the right top corner
+1. Click *Edit configruration...* on the right top corner
 
-- Click the plus icon
+1. Click the plus icon
 
-- Choose *Liferay Server*
+1. Choose *Liferay Server*
 
-- You can leave the config values by default or change to what you want
+1. You can leave the config values by default or change to what you want
 
-- Click *OK* Bundle
+1. Click *OK* Bundle
 
-- After you add a new *Liferay Server*, you can *start* or *debug* it
+1. After you add a new *Liferay Server*, you can *start* or *debug* it
 
 ### Liferay Module
 
@@ -67,15 +67,15 @@ You must have one Liferay Workspace Project to do the following steps:
 
 - Right click on existing Liferay Workspace Project and choose *New* > *Liferay Module*
 
-- Choose *Liferay Modules*
+1. Choose *Liferay Modules*
 
-- Depends on what template you choose, you can type *Package Name*, *Class Name* and *Service Name*
+1. Depends on what template you choose, you can type *Package Name*, *Class Name* and *Service Name*
 
-- Click *Next* Button
+1. Click *Next* Button
 
-- Type *Project Name* and the *location* is not able to customize.
+1. Type *Project Name* and the *location* is not able to customize.
 
-- Click *Finish* Button
+1. Click *Finish* Button
 
 ### Deployment
 
@@ -83,9 +83,9 @@ After you get the Liferay Modules you can deploy them to running or debugging Li
 
 - Right Click on your *Liferay Module*
 
-- Choose Liferay > Deploy
+1. Choose Liferay > Deploy
 
-- When you see the log showing in the console view, you get your module successful deploying
+1. When you see the log showing in the console view, you get your module successful deploying
 
 ### Watch
 
@@ -93,25 +93,25 @@ After you get the Liferay Modules you can *watch* them on running or debugging L
 
 - Right Click on your *Liferay Module* or the folders like modules or the root of Liferay Workspace.
 
-- Choose Liferay > Watch
+1. Choose Liferay > Watch
 
-- When you see the gradle console output and the deplog log showing in the console view, you get your module successful deploying.
+1. When you see the gradle console output and the deplog log showing in the console view, you get your module successful deploying.
 
-- You could keep the watch task running and it will listen on the changes of your coding.
+1. You could keep the watch task running and it will listen on the changes of your coding.
 
-- You could click red button to cancel the running watch task in Gradle Task view.
+1. You could click red button to cancel the running watch task in Gradle Task view.
 
 ### Better Editors for Liferay Files
 
 - service.xml
 
-- custom-sql/default.xml
+1. custom-sql/default.xml
 
-- portlet-model-hints.xml
+1. portlet-model-hints.xml
 
-- Liferay Taglib Support for Jsp files(Ultimate Only)
+1. Liferay Taglib Support for Jsp files(Ultimate Only)
 
-- etc.
+1. etc.
 
 ## License
 

--- a/README.markdown
+++ b/README.markdown
@@ -25,93 +25,93 @@ You can install this using _Preferences > Plugins > Install plugin from disk... 
 
 ### Liferay Workspace
 
-1. Create a Liferay Workspace Project from Start menu > click *Create New Project* or click *File* > *New* > *Project*
+- Create a Liferay Workspace Project from Start menu > click *Create New Project* or click *File* > *New* > *Project*
 
-2. Choose *Liferay Workspace* from left list
+- Choose *Liferay Workspace* from left list
 
-3. Click *Next* button
+- Click *Next* button
 
-4. Type your Liferay Workspace *Project Name* and choose a *Project Location* or leave it default.
+- Type your Liferay Workspace *Project Name* and choose a *Project Location* or leave it default.
 
-5. Click *Finish* button and there will be one popup show up.
+- Click *Finish* button and there will be one popup show up.
 
-6. Click *OK* to finish
+- Click *OK* to finish
 
 ### Liferay Server
 
 You must have one Liferay Workspace Project to do the following steps:
 
-1. Right click on the root of your Liferay Workspace Project
+- Right click on the root of your Liferay Workspace Project
 
-2. Click Liferay > InitBundle
+- Click Liferay > InitBundle
 
-3. Then the gradle will run *initBundle* task
+- Then the gradle will run *initBundle* task
 
-4. It will take several minutes to download the latest Liferay Server from remote if you don't have the local cache
+- It will take several minutes to download the latest Liferay Server from remote if you don't have the local cache
 
-5. Click *Edit configruration...* on the right top corner
+- Click *Edit configruration...* on the right top corner
 
-6. Click the plus icon
+- Click the plus icon
 
-7. Choose *Liferay Server*
+- Choose *Liferay Server*
 
-8. You can leave the config values by default or change to what you want
+- You can leave the config values by default or change to what you want
 
-9. Click *OK* Bundle
+- Click *OK* Bundle
 
-10. After you add a new *Liferay Server*, you can *start* or *debug* it
+- After you add a new *Liferay Server*, you can *start* or *debug* it
 
 ### Liferay Module
 
 You must have one Liferay Workspace Project to do the following steps:
 
-1. Right click on existing Liferay Workspace Project and choose *New* > *Liferay Module*
+- Right click on existing Liferay Workspace Project and choose *New* > *Liferay Module*
 
-2. Choose *Liferay Modules*
+- Choose *Liferay Modules*
 
-3. Depends on what template you choose, you can type *Package Name*, *Class Name* and *Service Name*
+- Depends on what template you choose, you can type *Package Name*, *Class Name* and *Service Name*
 
-4. Click *Next* Button
+- Click *Next* Button
 
-5. Type *Project Name* and the *location* is not able to customize.
+- Type *Project Name* and the *location* is not able to customize.
 
-6. Click *Finish* Button
+- Click *Finish* Button
 
 ### Deployment
 
 After you get the Liferay Modules you can deploy them to running or debugging Liferay Server:
 
-1. Right Click on your *Liferay Module*
+- Right Click on your *Liferay Module*
 
-2. Choose Liferay > Deploy
+- Choose Liferay > Deploy
 
-3. When you see the log showing in the console view, you get your module successful deploying
+- When you see the log showing in the console view, you get your module successful deploying
 
 ### Watch
 
 After you get the Liferay Modules you can *watch* them on running or debugging Liferay Server:
 
-1. Right Click on your *Liferay Module* or the folders like modules or the root of Liferay Workspace.
+- Right Click on your *Liferay Module* or the folders like modules or the root of Liferay Workspace.
 
-2. Choose Liferay > Watch
+- Choose Liferay > Watch
 
-3. When you see the gradle console output and the deplog log showing in the console view, you get your module successful deploying.
+- When you see the gradle console output and the deplog log showing in the console view, you get your module successful deploying.
 
-4. You could keep the watch task running and it will listen on the changes of your coding.
+- You could keep the watch task running and it will listen on the changes of your coding.
 
-5. You could click red button to cancel the running watch task in Gradle Task view.
+- You could click red button to cancel the running watch task in Gradle Task view.
 
 ### Better Editors for Liferay Files
 
-1. service.xml
+- service.xml
 
-2. custom-sql/default.xml
+- custom-sql/default.xml
 
-3. portlet-model-hints.xml
+- portlet-model-hints.xml
 
-4. Liferay Taglib Support for Jsp files(Ultimate Only)
+- Liferay Taglib Support for Jsp files(Ultimate Only)
 
-5. etc.
+- etc.
 
 ## License
 

--- a/README.markdown
+++ b/README.markdown
@@ -24,54 +24,93 @@ You can install this using _Preferences > Plugins > Install plugin from disk... 
 ## Key features
 
 ### Liferay Workspace
+
 1. Create a Liferay Workspace Project from Start menu > click *Create New Project* or click *File* > *New* > *Project*
+
 2. Choose *Liferay Workspace* from left list
+
 3. Click *Next* button
+
 4. Type your Liferay Workspace *Project Name* and choose a *Project Location* or leave it default.
+
 5. Click *Finish* button and there will be one popup show up.
+
 6. Click *OK* to finish
 
 ### Liferay Server
+
 You must have one Liferay Workspace Project to do the following steps:
+
 1. Right click on the root of your Liferay Workspace Project
+
 2. Click Liferay > InitBundle
+
 3. Then the gradle will run *initBundle* task
+
 4. It will take several minutes to download the latest Liferay Server from remote if you don't have the local cache
+
 5. Click *Edit configruration...* on the right top corner
+
 6. Click the plus icon
+
 7. Choose *Liferay Server*
+
 8. You can leave the config values by default or change to what you want
+
 9. Click *OK* Bundle
+
 10. After you add a new *Liferay Server*, you can *start* or *debug* it
 
 ### Liferay Module
+
 You must have one Liferay Workspace Project to do the following steps:
+
 1. Right click on existing Liferay Workspace Project and choose *New* > *Liferay Module*
+
 2. Choose *Liferay Modules*
+
 3. Depends on what template you choose, you can type *Package Name*, *Class Name* and *Service Name*
+
 4. Click *Next* Button
+
 5. Type *Project Name* and the *location* is not able to customize.
+
 6. Click *Finish* Button
 
 ### Deployment
+
 After you get the Liferay Modules you can deploy them to running or debugging Liferay Server:
+
 1. Right Click on your *Liferay Module*
+
 2. Choose Liferay > Deploy
+
 3. When you see the log showing in the console view, you get your module successful deploying
 
 ### Watch
+
 After you get the Liferay Modules you can *watch* them on running or debugging Liferay Server:
+
 1. Right Click on your *Liferay Module* or the folders like modules or the root of Liferay Workspace.
+
 2. Choose Liferay > Watch
+
 3. When you see the gradle console output and the deplog log showing in the console view, you get your module successful deploying.
+
 4. You could keep the watch task running and it will listen on the changes of your coding.
+
 5. You could click red button to cancel the running watch task in Gradle Task view.
 
 ### Better Editors for Liferay Files
+
 1. service.xml
+
 2. custom-sql/default.xml
+
 3. portlet-model-hints.xml
+
 4. Liferay Taglib Support for Jsp files(Ultimate Only)
+
 5. etc.
 
 ## License

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,19 @@
 buildscript {
 	dependencies {
 		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.source.formatter", version: "latest.release"
+		classpath group: "de.undercouch", name: "gradle-download-task", version: "4.0.0"
 		classpath group: "nu.studer", name: "gradle-credentials-plugin", version: "2.1"
 	}
 
 	repositories {
 		maven {
+			url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+		}
+		maven {
 			url "https://www.jetbrains.com/intellij-repository/snapshots"
 		}
 		maven {
 			url "https://oss.sonatype.org/content/repositories/snapshots/"
-		}
-		maven {
-			url "https://repository-cdn.liferay.com/nexus/content/groups/public"
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -296,4 +296,4 @@ verifyBladeLatest {
 	checksum bladeLatestMD5
 }
 
-version = "2.0.0"
+version = "2.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -280,6 +280,8 @@ test {
 	testLogging {
 		exceptionFormat = "full"
 	}
+	scanForTestClasses false
+	include "**/*Test.class"
 }
 
 verifyBlade392 {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 bladeBuildOutputDir=build/resources/main/libs/
 blade392DownloadURL=https://repository.liferay.com/nexus/content/repositories/public/com/liferay/blade/com.liferay.blade.cli/3.9.2/com.liferay.blade.cli-3.9.2.jar
 blade392MD5=08aedcb6bacc3166060d0032f9489dd1
-bladeLatestDownloadURL=https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/blade/com.liferay.blade.cli/4.0.10/com.liferay.blade.cli-4.0.10.jar
-bladeLatestMD5=ab05ce867ace1c8525365ddc47c81d31
+bladeLatestDownloadURL=https://repository.liferay.com/nexus/content/repositories/liferay-public-snapshots/com/liferay/blade/com.liferay.blade.cli/4.0.11-SNAPSHOT/com.liferay.blade.cli-4.0.11-20211223.051218-3.jar
+bladeLatestMD5=b7fcd9636f2a8ac9b567f07c25740556

--- a/src/main/java/com/liferay/ide/idea/language/tag/LiferayTaglibClassNameReferenceContributor.java
+++ b/src/main/java/com/liferay/ide/idea/language/tag/LiferayTaglibClassNameReferenceContributor.java
@@ -48,6 +48,7 @@ public class LiferayTaglibClassNameReferenceContributor extends AbstractLiferayT
 
 		javaClassReferenceProvider.setOption(JavaClassReferenceProvider.ADVANCED_RESOLVE, Boolean.TRUE);
 		javaClassReferenceProvider.setOption(JavaClassReferenceProvider.RESOLVE_QUALIFIED_CLASS_NAME, Boolean.TRUE);
+		javaClassReferenceProvider.setOption(JavaClassReferenceProvider.ALLOW_DOLLAR_NAMES, Boolean.FALSE);
 
 		return javaClassReferenceProvider;
 	}

--- a/src/main/java/com/liferay/ide/idea/server/LiferayDockerServerDebuggerRunner.java
+++ b/src/main/java/com/liferay/ide/idea/server/LiferayDockerServerDebuggerRunner.java
@@ -25,6 +25,7 @@ import com.intellij.debugger.impl.DebuggerSession;
 import com.intellij.debugger.impl.GenericDebuggerRunnerSettings;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.RemoteConnection;
+import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.configurations.RunnerSettings;
@@ -50,7 +51,7 @@ import org.jetbrains.annotations.Nullable;
  * @author Simon Jiang
  */
 public class LiferayDockerServerDebuggerRunner
-	extends ExternalSystemTaskDebugRunner implements ILiferayDockerServerRunnerCallback {
+	extends ExternalSystemTaskDebugRunner implements ILiferayDockerServerRunnerCallback, ServerRunnerChecker {
 
 	@Override
 	public boolean canRun(@NotNull String executorId, @NotNull RunProfile runProfile) {
@@ -67,6 +68,11 @@ public class LiferayDockerServerDebuggerRunner
 	@Override
 	public String getRunnerId() {
 		return "LiferayDockerServerDebuggerRunner";
+	}
+
+	@Override
+	public boolean isLiferayServerRunConfiguration(RunConfiguration runConfiguration) {
+		return runConfiguration instanceof LiferayDockerServerConfiguration;
 	}
 
 	@Nullable

--- a/src/main/java/com/liferay/ide/idea/server/LiferayDockerServerRunner.java
+++ b/src/main/java/com/liferay/ide/idea/server/LiferayDockerServerRunner.java
@@ -17,6 +17,7 @@ package com.liferay.ide.idea.server;
 import com.intellij.build.BuildView;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.ExecutionResult;
+import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.executors.DefaultRunExecutor;
@@ -33,7 +34,8 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @author Simon Jiang
  */
-public class LiferayDockerServerRunner extends GenericProgramRunner implements ILiferayDockerServerRunnerCallback {
+public class LiferayDockerServerRunner
+	extends GenericProgramRunner implements ILiferayDockerServerRunnerCallback, ServerRunnerChecker {
 
 	@Override
 	public boolean canRun(@NotNull String executorId, @NotNull RunProfile runProfile) {
@@ -50,6 +52,11 @@ public class LiferayDockerServerRunner extends GenericProgramRunner implements I
 	@Override
 	public String getRunnerId() {
 		return "LiferayDockerServerRunner";
+	}
+
+	@Override
+	public boolean isLiferayServerRunConfiguration(RunConfiguration runConfiguration) {
+		return runConfiguration instanceof LiferayDockerServerConfiguration;
 	}
 
 	@Override

--- a/src/main/java/com/liferay/ide/idea/server/LiferayServerConfigurable.java
+++ b/src/main/java/com/liferay/ide/idea/server/LiferayServerConfigurable.java
@@ -78,7 +78,7 @@ public class LiferayServerConfigurable
 					PortalBundle portalBundle = ServerUtil.getPortalBundle(FileUtil.getPath(_liferayServer.getText()));
 
 					if (portalBundle != null) {
-						_bundleType.setText(portalBundle.getType());
+						_bundleType.setText(portalBundle.getDisplayName());
 					}
 					else {
 						_bundleType.setText("");
@@ -94,12 +94,21 @@ public class LiferayServerConfigurable
 
 	@Override
 	public void applyEditorTo(@NotNull LiferayServerConfiguration configuration) throws ConfigurationException {
-		ModulesComboBox modulesComboBox = _modules.getComponent();
-
 		configuration.setAlternativeJrePath(_jrePath.getJrePathOrName());
 		configuration.setAlternativeJrePathEnabled(_jrePath.isAlternativeJreSelected());
 		configuration.setBundleLocation(_liferayServer.getText());
-		configuration.setBundleType(_bundleType.getText());
+
+		PortalBundle portalBundle = ServerUtil.getPortalBundle(Paths.get(_liferayServer.getText()));
+
+		if (portalBundle != null) {
+			configuration.setBundleType(portalBundle.getType());
+		}
+		else {
+			throw new ConfigurationException("Portal bundle type is invalid");
+		}
+
+		ModulesComboBox modulesComboBox = _modules.getComponent();
+
 		configuration.setDeveloperMode(_developerMode.isSelected());
 		configuration.setModule(modulesComboBox.getSelectedModule());
 		configuration.setVMParameters(_vmParams.getText());
@@ -130,7 +139,7 @@ public class LiferayServerConfigurable
 		if (portalBundle != null) {
 			_liferayServer.setText(String.valueOf(portalBundle.getAppServerDir()));
 
-			_bundleType.setText(portalBundle.getType());
+			_bundleType.setText(portalBundle.getDisplayName());
 		}
 		else {
 			Project project = configuration.getProject();

--- a/src/main/java/com/liferay/ide/idea/server/LiferayServerDebuggerRunner.java
+++ b/src/main/java/com/liferay/ide/idea/server/LiferayServerDebuggerRunner.java
@@ -18,6 +18,7 @@ import com.intellij.debugger.impl.GenericDebuggerRunner;
 import com.intellij.debugger.settings.DebuggerSettings;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.ExecutionManager;
+import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.executors.DefaultDebugExecutor;
@@ -37,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
  * @author Terry Jia
  * @author Simon Jiang
  */
-public class LiferayServerDebuggerRunner extends GenericDebuggerRunner {
+public class LiferayServerDebuggerRunner extends GenericDebuggerRunner implements ServerRunnerChecker {
 
 	@Override
 	public boolean canRun(@NotNull String executorId, @NotNull RunProfile runProfile) {
@@ -54,11 +55,18 @@ public class LiferayServerDebuggerRunner extends GenericDebuggerRunner {
 		return "LiferayServerDebuggerRunner";
 	}
 
+	@Override
+	public boolean isLiferayServerRunConfiguration(RunConfiguration runConfiguration) {
+		return runConfiguration instanceof LiferayServerConfiguration;
+	}
+
 	@Nullable
 	@Override
 	protected RunContentDescriptor doExecute(
 			@NotNull RunProfileState runProfileState, @NotNull ExecutionEnvironment executionEnvironment)
 		throws ExecutionException {
+
+		verifyRunningServer(executionEnvironment);
 
 		DebuggerSettings debuggerSettings = DebuggerSettings.getInstance();
 

--- a/src/main/java/com/liferay/ide/idea/server/LiferayServerRunner.java
+++ b/src/main/java/com/liferay/ide/idea/server/LiferayServerRunner.java
@@ -16,6 +16,7 @@ package com.liferay.ide.idea.server;
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.ExecutionManager;
+import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.executors.DefaultRunExecutor;
@@ -36,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
  * @author Terry Jia
  * @author Simon Jiang
  */
-public class LiferayServerRunner extends DefaultJavaProgramRunner {
+public class LiferayServerRunner extends DefaultJavaProgramRunner implements ServerRunnerChecker {
 
 	@Override
 	public boolean canRun(@NotNull String executorId, @NotNull RunProfile runProfile) {
@@ -53,10 +54,17 @@ public class LiferayServerRunner extends DefaultJavaProgramRunner {
 		return "LiferayServerRunner";
 	}
 
+	@Override
+	public boolean isLiferayServerRunConfiguration(RunConfiguration runConfiguration) {
+		return runConfiguration instanceof LiferayServerConfiguration;
+	}
+
 	@Nullable
 	@Override
 	protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment environment)
 		throws ExecutionException {
+
+		verifyRunningServer(environment);
 
 		RunContentDescriptor runContentDescriptor = super.doExecute(state, environment);
 

--- a/src/main/java/com/liferay/ide/idea/server/ServerRunnerChecker.java
+++ b/src/main/java/com/liferay/ide/idea/server/ServerRunnerChecker.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.server;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.ExecutionManager;
+import com.intellij.execution.RunManager;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.ui.RunContentDescriptor;
+import com.intellij.execution.ui.RunContentManager;
+
+import java.text.MessageFormat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author Simon Jiang
+ */
+public interface ServerRunnerChecker {
+
+	public default List<String> getServerRunConfigurationNames(@NotNull ExecutionEnvironment environment) {
+		RunManager runManager = RunManager.getInstance(environment.getProject());
+
+		List<RunConfiguration> allConfigurationsList = runManager.getAllConfigurationsList();
+
+		return allConfigurationsList.stream(
+		).filter(
+			runConfiguration -> isLiferayServerRunConfiguration(runConfiguration)
+		).map(
+			runConfiguration -> runConfiguration.getName()
+		).collect(
+			Collectors.toList()
+		);
+	}
+
+	public boolean isLiferayServerRunConfiguration(RunConfiguration runConfiguration);
+
+	public default void verifyRunningServer(@NotNull ExecutionEnvironment environment) throws ExecutionException {
+		RunContentManager runContentManager = RunContentManager.getInstance(environment.getProject());
+
+		List<String> runConfigurationNames = getServerRunConfigurationNames(environment);
+
+		ExecutionManager executionManager = ExecutionManager.getInstance(environment.getProject());
+
+		for (RunContentDescriptor runContentDescriptor : runContentManager.getAllDescriptors()) {
+			if (runConfigurationNames.contains(runContentDescriptor.getDisplayName())) {
+				ProcessHandler processHandler = runContentDescriptor.getProcessHandler();
+
+				boolean hasRunningServer = Arrays.stream(
+					executionManager.getRunningProcesses()
+				).filter(
+					process -> {
+						if (process.equals(processHandler) && !processHandler.isProcessTerminated() &&
+							!processHandler.isProcessTerminating()) {
+
+							return true;
+						}
+
+						return false;
+					}
+				).findAny(
+				).isPresent();
+
+				if (hasRunningServer) {
+					throw new ExecutionException(
+						MessageFormat.format(
+							"Found another server {0} is running", runContentDescriptor.getDisplayName()));
+				}
+			}
+		}
+	}
+
+}

--- a/src/main/java/com/liferay/ide/idea/server/portal/LayeredModulePathFactory.java
+++ b/src/main/java/com/liferay/ide/idea/server/portal/LayeredModulePathFactory.java
@@ -33,18 +33,29 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 /**
  * @author Brian Stansberry
  */
 public class LayeredModulePathFactory {
 
-	public static File[] getFilesForModule(File modulesFolder, String moduleName, String slot, FilenameFilter filter) {
+	public static File[] getFilesForModule(
+		File modulesFolder, String moduleName, String[] slots, FilenameFilter filter) {
+
 		String slashed = moduleName.replaceAll("\\.", "/");
 
-		slot = (slot == null) ? "main" : slot;
+		slots = (slots == null) ? new String[] {"main"} : slots;
 
-		return _getFiles(modulesFolder, Paths.get(slashed, slot), filter);
+		return Stream.of(
+			slots
+		).map(
+			slot -> Objects.isNull(slot) ? "main" : slot
+		).flatMap(
+			slot -> Stream.of(_getFiles(modulesFolder, Paths.get(slashed, slot), filter))
+		).toArray(
+			File[]::new
+		);
 	}
 
 	/**

--- a/src/main/java/com/liferay/ide/idea/server/portal/PortalBundle.java
+++ b/src/main/java/com/liferay/ide/idea/server/portal/PortalBundle.java
@@ -25,6 +25,8 @@ public interface PortalBundle {
 
 	public Path getAppServerDir();
 
+	public String getDisplayName();
+
 	public Path getLiferayHome();
 
 	public String getMainClass();

--- a/src/main/java/com/liferay/ide/idea/server/portal/PortalJBossBundle.java
+++ b/src/main/java/com/liferay/ide/idea/server/portal/PortalJBossBundle.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.server.portal;
+
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.util.lang.JavaVersion;
+
+import com.liferay.ide.idea.util.FileUtil;
+import com.liferay.ide.idea.util.ListUtil;
+
+import java.io.File;
+import java.io.FileFilter;
+
+import java.nio.file.Path;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.io.FileUtils;
+
+import org.jetbrains.jps.model.java.JdkVersionDetector;
+
+/**
+ * @author Seiphon Wang
+ */
+public class PortalJBossBundle extends AbstractPortalBundle {
+
+	public static final int DEFAULT_JMX_PORT = 2099;
+
+	public PortalJBossBundle(Path path) {
+		super(path);
+	}
+
+	@Override
+	public String getDisplayName() {
+		return "JBoss AS";
+	}
+
+	public int getJmxRemotePort() {
+		return getDefaultJMXRemotePort();
+	}
+
+	@Override
+	public String getMainClass() {
+		return "org.jboss.modules.Main";
+	}
+
+	@Override
+	public Path[] getRuntimeClasspath() {
+		List<Path> paths = new ArrayList<>();
+
+		if (FileUtil.exists(bundlePath)) {
+			paths.add(FileUtil.pathAppend(bundlePath, "jboss-modules.jar"));
+
+			Path loggManagerPath = FileUtil.pathAppend(
+				bundlePath, "modules/system/layers/base/org/jboss/logmanager/main");
+
+			File loggManagerFile = loggManagerPath.toFile();
+
+			if (FileUtil.exists(loggManagerFile)) {
+				File[] libFiles = loggManagerFile.listFiles(
+					new FileFilter() {
+
+						@Override
+						public boolean accept(File libFile) {
+							String libFileName = libFile.getName();
+
+							if (libFile.isFile() && libFileName.endsWith(".jar")) {
+								return true;
+							}
+
+							return false;
+						}
+
+					});
+
+				if (libFiles != null) {
+					for (File libFile : libFiles) {
+						paths.add(FileUtil.pathAppend(loggManagerPath, libFile.getName()));
+					}
+				}
+			}
+		}
+
+		return paths.toArray(new Path[0]);
+	}
+
+	@Override
+	public String[] getRuntimeStartProgArgs() {
+		List<String> args = new ArrayList<>();
+
+		args.add("-mp");
+
+		Path modulesPath = FileUtil.pathAppend(bundlePath, "modules");
+
+		args.add(modulesPath.toString());
+
+		args.add("-jaxpmodule");
+		args.add("javax.xml.jaxp-provider");
+		args.add("org.jboss.as.standalone");
+		args.add("-b");
+		args.add("localhost");
+		args.add("--server-config=standalone.xml");
+		args.add("-Djboss.server.base.dir=" + FileUtil.pathAppend(bundlePath, "standalone"));
+
+		return args.toArray(new String[0]);
+	}
+
+	@Override
+	public String[] getRuntimeStartVMArgs(Sdk sdk) {
+		List<String> args = getDefaultRuntimeStartVMArgs();
+
+		JdkVersionDetector jdkVersionDetector = JdkVersionDetector.getInstance();
+
+		JdkVersionDetector.JdkVersionInfo jdkVersionInfo = jdkVersionDetector.detectJdkVersionInfo(sdk.getHomePath());
+
+		if (jdkVersionInfo != null) {
+			JavaVersion jdkVersion = jdkVersionInfo.version;
+			JavaVersion jdk8Version = JavaVersion.compose(8);
+
+			if (jdkVersion.compareTo(jdk8Version) <= 0) {
+				File jbossLogmanagerJarFile = getJbossLib(bundlePath, "/modules/org/jboss/logmanager/main/");
+
+				if (Objects.nonNull(jbossLogmanagerJarFile)) {
+					args.add("-Xbootclasspath/p:" + jbossLogmanagerJarFile.getAbsolutePath());
+				}
+
+				File jbossLogmanagerLog4jJarFile = getJbossLib(bundlePath, "/modules/org/jboss/logmanager/log4j/main/");
+
+				if (Objects.nonNull(jbossLogmanagerLog4jJarFile)) {
+					args.add("-Xbootclasspath/p:" + jbossLogmanagerLog4jJarFile.getAbsolutePath());
+				}
+
+				File jbosslog4jJarFile = getJbossLib(bundlePath, "/modules/org/apache/log4j/main/");
+
+				if (Objects.nonNull(jbosslog4jJarFile)) {
+					args.add("-Xbootclasspath/p:" + jbosslog4jJarFile.getAbsolutePath());
+				}
+			}
+		}
+
+		return args.toArray(new String[0]);
+	}
+
+	@Override
+	public String getType() {
+		return "jboss";
+	}
+
+	protected int getDefaultJMXRemotePort() {
+		return DEFAULT_JMX_PORT;
+	}
+
+	protected List<String> getDefaultRuntimeStartVMArgs() {
+		List<String> args = new ArrayList<>();
+
+		args.add("-Dcom.sun.management.jmxremote");
+		args.add("-Dcom.sun.management.jmxremote.authenticate=false");
+		args.add("-Dcom.sun.management.jmxremote.port=" + getJmxRemotePort());
+		args.add("-Dcom.sun.management.jmxremote.ssl=false");
+		args.add("-Dorg.jboss.resolver.warning=true");
+		args.add("-Djava.net.preferIPv4Stack=true");
+		args.add("-Dsun.rmi.dgc.client.gcInterval=3600000");
+		args.add("-Dsun.rmi.dgc.server.gcInterval=3600000");
+		args.add("-Djboss.modules.system.pkgs=org.jboss.byteman");
+		args.add("-Djava.awt.headless=true");
+		args.add("-Dfile.encoding=UTF8");
+		args.add("-server");
+		args.add("-Djava.util.logging.manager=org.jboss.logmanager.LogManager");
+
+		args.add("-Djboss.modules.system.pkgs=org.jboss.logmanager");
+		args.add("-Dorg.jboss.boot.log.file=" + FileUtil.pathAppend(bundlePath, "standalone/log/boot.log"));
+		args.add(
+			"-Dlogging.configuration=file:" +
+				FileUtil.pathAppend(bundlePath, "standalone/configuration/logging.properties"));
+		args.add("-Djboss.home.dir=" + bundlePath);
+		args.add("-Djboss.bind.address.management=localhost");
+		args.add("-Duser.timezone=GMT");
+
+		return args;
+	}
+
+	protected File getJbossLib(Path bundlePath, String libPathValue) {
+		Path libIPath = FileUtil.pathAppend(bundlePath, libPathValue);
+
+		Collection<File> libJars = FileUtils.listFiles(libIPath.toFile(), new String[] {"jar"}, true);
+
+		File[] jarArray = libJars.toArray(new File[0]);
+
+		if (ListUtil.isNotEmpty(jarArray)) {
+			return jarArray[0];
+		}
+
+		return null;
+	}
+
+}

--- a/src/main/java/com/liferay/ide/idea/server/portal/PortalJBossBundleFactory.java
+++ b/src/main/java/com/liferay/ide/idea/server/portal/PortalJBossBundleFactory.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.server.portal;
+
+import com.liferay.ide.idea.util.FileUtil;
+import com.liferay.ide.idea.util.JavaUtil;
+
+import java.io.File;
+
+import java.nio.file.Path;
+
+/**
+ * @author Seiphon Wang
+ */
+public class PortalJBossBundleFactory extends AbstractPortalBundleFactory {
+
+	@Override
+	public PortalBundle create(Path location) {
+		return new PortalJBossBundle(location);
+	}
+
+	@Override
+	public String getType() {
+		return "jboss";
+	}
+
+	@Override
+	protected boolean detectAppServerPath(Path path) {
+		if (FileUtil.notExists(path)) {
+			return false;
+		}
+
+		Path bundlesPath = FileUtil.pathAppend(path, "bundles");
+		Path modulesPath = FileUtil.pathAppend(path, "modules");
+		Path standalonePath = FileUtil.pathAppend(path, "standalone");
+		Path binPath = FileUtil.pathAppend(path, "bin");
+
+		if (FileUtil.exists(bundlesPath) && FileUtil.exists(modulesPath) && FileUtil.exists(standalonePath) &&
+			FileUtil.exists(binPath)) {
+
+			File mainFolder = new File("modules/org/jboss/as/server/main");
+
+			Path mainFolderPath = mainFolder.toPath();
+
+			return JavaUtil.scanFolderJarsForManifestProp(
+				path.toFile(), mainFolderPath.toString(), _JBAS7_RELEASE_VERSION, "7.");
+		}
+
+		return false;
+	}
+
+	private static final String _JBAS7_RELEASE_VERSION = "JBossAS-Release-Version";
+
+}

--- a/src/main/java/com/liferay/ide/idea/server/portal/PortalJBossEapBundle.java
+++ b/src/main/java/com/liferay/ide/idea/server/portal/PortalJBossEapBundle.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.server.portal;
+
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.util.lang.JavaVersion;
+
+import java.io.File;
+
+import java.nio.file.Path;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.jetbrains.jps.model.java.JdkVersionDetector;
+
+/**
+ * @author Seiphon Wang
+ */
+public class PortalJBossEapBundle extends PortalJBossBundle {
+
+	public PortalJBossEapBundle(Path path) {
+		super(path);
+	}
+
+	@Override
+	public String getDisplayName() {
+		return "JBoss EAP";
+	}
+
+	@Override
+	public String[] getRuntimeStartVMArgs(Sdk sdk) {
+		List<String> args = getDefaultRuntimeStartVMArgs();
+
+		JdkVersionDetector jdkVersionDetector = JdkVersionDetector.getInstance();
+
+		JdkVersionDetector.JdkVersionInfo jdkVersionInfo = jdkVersionDetector.detectJdkVersionInfo(sdk.getHomePath());
+
+		if (jdkVersionInfo != null) {
+			JavaVersion jdkVersion = jdkVersionInfo.version;
+			JavaVersion jdk9Version = JavaVersion.compose(9);
+
+			File wildflyCommonLib = getJbossLib(bundlePath, "/modules/system/layers/base/org/wildfly/common/main/");
+
+			if (jdkVersion.compareTo(jdk9Version) < 0) {
+				File log4jJbossLogmanager = getJbossLib(
+					bundlePath, "/modules/system/layers/base/org/jboss/log4j/logmanager/main/");
+
+				if (Objects.nonNull(log4jJbossLogmanager)) {
+					args.add("-Xbootclasspath/p:" + log4jJbossLogmanager.getAbsolutePath());
+				}
+
+				if (Objects.nonNull(wildflyCommonLib)) {
+					args.add("-Xbootclasspath/p:" + wildflyCommonLib.getAbsolutePath());
+				}
+
+				File jbossLogManagerLib = getJbossLib(
+					bundlePath, "/modules/system/layers/base/org/jboss/logmanager/main/");
+
+				if (Objects.nonNull(jbossLogManagerLib)) {
+					args.add("-Xbootclasspath/p:" + jbossLogManagerLib.getAbsolutePath());
+				}
+			}
+			else if (Objects.nonNull(wildflyCommonLib)) {
+				args.add("-Xbootclasspath/a:" + wildflyCommonLib.getAbsolutePath());
+
+				args.add("--add-modules=java.se");
+			}
+		}
+
+		args.add("-Dorg.jboss.logmanager.nocolor=true");
+
+		return args.toArray(new String[0]);
+	}
+
+	@Override
+	public String getType() {
+		return "jboss_eap";
+	}
+
+}

--- a/src/main/java/com/liferay/ide/idea/server/portal/PortalJBossEapBundleFactory.java
+++ b/src/main/java/com/liferay/ide/idea/server/portal/PortalJBossEapBundleFactory.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ide.idea.server.portal;
+
+import com.liferay.ide.idea.util.FileUtil;
+import com.liferay.ide.idea.util.JavaUtil;
+import com.liferay.ide.idea.util.PropertiesUtil;
+
+import java.io.File;
+
+import java.nio.file.Path;
+
+import java.util.Properties;
+
+/**
+ * @author Seiphon Wang
+ */
+public class PortalJBossEapBundleFactory extends PortalJBossBundleFactory {
+
+	public static String getEAPVersionNoSlotCheck(
+		File location, String metaInfPath, String[] versionPrefixs, String releaseName) {
+
+		Path rootPath = location.toPath();
+
+		Path eapDir = FileUtil.pathAppend(rootPath, metaInfPath);
+
+		if (FileUtil.exists(eapDir)) {
+			Path manifest = FileUtil.pathAppend(eapDir, "MANIFEST.MF");
+
+			String type = JavaUtil.getManifestProperty(manifest.toFile(), "JBoss-Product-Release-Name");
+			String version = JavaUtil.getManifestProperty(manifest.toFile(), "JBoss-Product-Release-Version");
+
+			boolean matchesName = type.contains(releaseName);
+
+			for (String prefixVersion : versionPrefixs) {
+				boolean matchesVersion = version.startsWith(prefixVersion);
+
+				if (matchesName && matchesVersion) {
+					return version;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public PortalBundle create(Path location) {
+		return new PortalJBossEapBundle(location);
+	}
+
+	@Override
+	public String getType() {
+		return "jboss_eap";
+	}
+
+	@Override
+	protected boolean detectAppServerPath(Path path) {
+		if (FileUtil.notExists(path)) {
+			return false;
+		}
+
+		Path modulesPath = FileUtil.pathAppend(path, "modules");
+		Path standalonePath = FileUtil.pathAppend(path, "standalone");
+		Path binPath = FileUtil.pathAppend(path, "bin");
+
+		if (FileUtil.exists(modulesPath) && FileUtil.exists(standalonePath) && FileUtil.exists(binPath)) {
+			String eapVersion = _getEAPVersion(
+				path.toFile(), _EAP_DIR_META_INF, new String[] {"6.", "7."}, "eap", "EAP");
+
+			if (eapVersion != null) {
+				return true;
+			}
+
+			return super.detectAppServerPath(path);
+		}
+
+		return false;
+	}
+
+	private String _getEAPVersion(
+		File location, String metaInfPath, String[] versionPrefix, String slot, String releaseName) {
+
+		Path rootPath = location.toPath();
+
+		Path productConf = FileUtil.pathAppend(rootPath, "bin/product.conf");
+
+		if (FileUtil.exists(productConf)) {
+			Properties p = PropertiesUtil.loadProperties(productConf.toFile());
+
+			if (p != null) {
+				String product = (String)p.get("slot");
+
+				if (slot.equals(product)) {
+					return getEAPVersionNoSlotCheck(location, metaInfPath, versionPrefix, releaseName);
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static final String _EAP_DIR_META_INF = "modules/system/layers/base/org/jboss/as/product/eap/dir/META-INF";
+
+}

--- a/src/main/java/com/liferay/ide/idea/server/portal/PortalTomcatBundle.java
+++ b/src/main/java/com/liferay/ide/idea/server/portal/PortalTomcatBundle.java
@@ -36,6 +36,11 @@ public class PortalTomcatBundle extends AbstractPortalBundle {
 	}
 
 	@Override
+	public String getDisplayName() {
+		return "Tomcat";
+	}
+
+	@Override
 	public String getMainClass() {
 		return "org.apache.catalina.startup.Bootstrap";
 	}

--- a/src/main/java/com/liferay/ide/idea/server/portal/PortalTomcatBundle.java
+++ b/src/main/java/com/liferay/ide/idea/server/portal/PortalTomcatBundle.java
@@ -15,8 +15,8 @@
 package com.liferay.ide.idea.server.portal;
 
 import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.util.lang.JavaVersion;
 
-import com.liferay.ide.idea.util.CoreUtil;
 import com.liferay.ide.idea.util.FileUtil;
 
 import java.nio.file.Path;
@@ -25,8 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jetbrains.jps.model.java.JdkVersionDetector;
-
-import org.osgi.framework.Version;
 
 /**
  * @author Simon Jiang
@@ -99,12 +97,9 @@ public class PortalTomcatBundle extends AbstractPortalBundle {
 
 		JdkVersionDetector.JdkVersionInfo jdkVersionInfo = jdkVersionDetector.detectJdkVersionInfo(sdk.getHomePath());
 
-		String jdkVersionString = String.valueOf(jdkVersionInfo.version);
-
-		if (!CoreUtil.isNullOrEmpty(jdkVersionString)) {
-			Version jdkVersion = Version.parseVersion(jdkVersionString);
-
-			Version jdk8Version = Version.parseVersion("1.8");
+		if (jdkVersionInfo != null) {
+			JavaVersion jdkVersion = jdkVersionInfo.version;
+			JavaVersion jdk8Version = JavaVersion.compose(8);
 
 			if (jdkVersion.compareTo(jdk8Version) <= 0) {
 				args.add("-Djava.endorsed.dirs=" + endorsedPath);

--- a/src/main/java/com/liferay/ide/idea/server/portal/PortalWildFlyBundle.java
+++ b/src/main/java/com/liferay/ide/idea/server/portal/PortalWildFlyBundle.java
@@ -37,7 +37,7 @@ import org.osgi.framework.Version;
 /**
  * @author Simon Jiang
  */
-public class PortalWildFlyBundle extends AbstractPortalBundle {
+public class PortalWildFlyBundle extends PortalJBossBundle {
 
 	public static final int DEFAULT_JMX_PORT = 2099;
 
@@ -46,8 +46,8 @@ public class PortalWildFlyBundle extends AbstractPortalBundle {
 	}
 
 	@Override
-	public String getMainClass() {
-		return "org.jboss.modules.Main";
+	public String getDisplayName() {
+		return "JBoss Wildfly";
 	}
 
 	@Override
@@ -67,27 +67,6 @@ public class PortalWildFlyBundle extends AbstractPortalBundle {
 		}
 
 		return paths.toArray(new Path[0]);
-	}
-
-	@Override
-	public String[] getRuntimeStartProgArgs() {
-		List<String> args = new ArrayList<>();
-
-		args.add("-mp");
-
-		Path modulesPath = FileUtil.pathAppend(bundlePath, "modules");
-
-		args.add(modulesPath.toString());
-
-		args.add("-jaxpmodule");
-		args.add("javax.xml.jaxp-provider");
-		args.add("org.jboss.as.standalone");
-		args.add("-b");
-		args.add("localhost");
-		args.add("--server-config=standalone.xml");
-		args.add("-Djboss.server.base.dir=" + FileUtil.pathAppend(bundlePath, "standalone"));
-
-		return args.toArray(new String[0]);
 	}
 
 	@Override

--- a/src/main/java/com/liferay/ide/idea/server/portal/PortalWildFlyBundle.java
+++ b/src/main/java/com/liferay/ide/idea/server/portal/PortalWildFlyBundle.java
@@ -14,6 +14,7 @@
 
 package com.liferay.ide.idea.server.portal;
 
+import com.intellij.openapi.projectRoots.JdkUtil;
 import com.intellij.openapi.projectRoots.Sdk;
 
 import com.liferay.ide.idea.util.FileUtil;
@@ -30,6 +31,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
+
+import org.osgi.framework.Version;
 
 /**
  * @author Simon Jiang
@@ -102,9 +105,17 @@ public class PortalWildFlyBundle extends AbstractPortalBundle {
 		args.add("-server");
 		args.add("-Djava.util.logging.manager=org.jboss.logmanager.LogManager");
 
-		addBootClasspath(bundlePath.toString(), "org.jboss.logmanager", args, "-Xbootclasspath/p:");
-		addBootClasspath(bundlePath.toString(), "org.jboss.log4j.logmanager", args, "-Xbootclasspath/p:");
-		addBootClasspath(bundlePath.toString(), "org.wildfly.common", args, "-Xbootclasspath/p:");
+		Version jdkVersion = Version.parseVersion(JdkUtil.suggestJdkName(sdk.getVersionString()));
+		Version jdk8Version = Version.parseVersion("1.8");
+
+		if (jdkVersion.compareTo(jdk8Version) <= 0) {
+			addBootClasspath(bundlePath.toString(), "org.jboss.logmanager", args, "-Xbootclasspath/p:");
+			addBootClasspath(bundlePath.toString(), "org.jboss.log4j.logmanager", args, "-Xbootclasspath/p:");
+			addBootClasspath(bundlePath.toString(), "org.wildfly.common", args, "-Xbootclasspath/p:");
+		}
+		else {
+			addBootClasspath(bundlePath.toString(), "org.wildfly.common", args, "-Xbootclasspath/a:");
+		}
 
 		args.add("-Dorg.jboss.boot.log.file=" + FileUtil.pathAppend(bundlePath, "standalone/log/boot.log"));
 		args.add(

--- a/src/main/java/com/liferay/ide/idea/server/portal/PortalWildFlyBundleFactory.java
+++ b/src/main/java/com/liferay/ide/idea/server/portal/PortalWildFlyBundleFactory.java
@@ -27,7 +27,7 @@ import org.osgi.framework.Version;
 /**
  * @author Simon Jiang
  */
-public class PortalWildFlyBundleFactory extends AbstractPortalBundleFactory {
+public class PortalWildFlyBundleFactory extends PortalJBossBundleFactory {
 
 	@Override
 	public PortalBundle create(Path location) {
@@ -63,8 +63,6 @@ public class PortalWildFlyBundleFactory extends AbstractPortalBundleFactory {
 
 				return detectAppServerPath(path);
 			}
-
-			return detectAppServerPath(path);
 		}
 
 		return false;

--- a/src/main/java/com/liferay/ide/idea/server/portal/PortalWildFlyBundleFactory.java
+++ b/src/main/java/com/liferay/ide/idea/server/portal/PortalWildFlyBundleFactory.java
@@ -51,8 +51,8 @@ public class PortalWildFlyBundleFactory extends AbstractPortalBundleFactory {
 
 		if (FileUtil.exists(modulesPath) && FileUtil.exists(standalonePath) && FileUtil.exists(binPath)) {
 			String versions = getManifestPropFromJBossModulesFolder(
-				new File[] {new File(path.toString(), "modules")}, "org.jboss.as.product", "wildfly-full/dir/META-INF",
-				JBOSS_RELEASE_VERSION);
+				new File[] {new File(path.toString(), "modules")}, "org.jboss.as.product",
+				new String[] {"wildfly-full/dir/META-INF", "main/dir/META-INF"}, JBOSS_RELEASE_VERSION);
 
 			if (versions != null) {
 				Version version = Version.parseVersion(versions);
@@ -71,13 +71,13 @@ public class PortalWildFlyBundleFactory extends AbstractPortalBundleFactory {
 	}
 
 	protected String getManifestPropFromJBossModulesFolder(
-		File[] moduleRoots, String moduleId, String slot, String property) {
+		File[] moduleRoots, String moduleId, String[] slots, String property) {
 
 		File[] layeredRoots = LayeredModulePathFactory.resolveLayeredModulePath(moduleRoots);
 
 		for (File layeredFile : layeredRoots) {
 			File[] manifests = LayeredModulePathFactory.getFilesForModule(
-				layeredFile, moduleId, slot, (dir, name) -> name.equalsIgnoreCase("manifest.mf"));
+				layeredFile, moduleId, slots, (dir, name) -> name.equalsIgnoreCase("manifest.mf"));
 
 			if (ListUtil.isNotEmpty(manifests)) {
 				String value = JavaUtil.getManifestProperty(manifests[0], property);

--- a/src/main/java/com/liferay/ide/idea/ui/modules/LiferayProjectTypesComponent.java
+++ b/src/main/java/com/liferay/ide/idea/ui/modules/LiferayProjectTypesComponent.java
@@ -214,11 +214,8 @@ public class LiferayProjectTypesComponent extends JPanel implements LiferayWorks
 				validationTitle);
 		}
 
-		ProjectManager projectManager = ProjectManager.getInstance();
 
-		Project workspaceProject = projectManager.getOpenProjects()[0];
-
-		if (LiferayWorkspaceSupport.isValidMavenWorkspaceProject(workspaceProject)) {
+		if (LiferayWorkspaceSupport.isValidMavenWorkspaceProject(_project)) {
 			if (Objects.equals(type, "form-field")) {
 				VersionRange requiredVersionRange = new VersionRange(
 					true, new Version("7.0"), new Version("7.2"), false);

--- a/src/main/java/com/liferay/ide/idea/ui/modules/LiferayProjectTypesComponent.java
+++ b/src/main/java/com/liferay/ide/idea/ui/modules/LiferayProjectTypesComponent.java
@@ -214,6 +214,17 @@ public class LiferayProjectTypesComponent extends JPanel implements LiferayWorks
 				validationTitle);
 		}
 
+		if (type.equals("war-core-ext")) {
+			Version notSupportFromPortalVersion = new Version("7.3");
+
+			Version currentVersion = Version.parseVersion(_liferayVersion);
+
+			if (currentVersion.compareTo(notSupportFromPortalVersion) >= 0) {
+				throw new ConfigurationException(
+					"War Core Ext project is only supported starting from portal 7.0 to 7.2", validationTitle);
+			}
+		}
+
 		ProjectManager projectManager = ProjectManager.getInstance();
 
 		Project workspaceProject = projectManager.getOpenProjects()[0];

--- a/src/main/java/com/liferay/ide/idea/ui/modules/LiferayProjectTypesComponent.java
+++ b/src/main/java/com/liferay/ide/idea/ui/modules/LiferayProjectTypesComponent.java
@@ -214,17 +214,6 @@ public class LiferayProjectTypesComponent extends JPanel implements LiferayWorks
 				validationTitle);
 		}
 
-		if (type.equals("war-core-ext")) {
-			Version notSupportFromPortalVersion = new Version("7.3");
-
-			Version currentVersion = Version.parseVersion(_liferayVersion);
-
-			if (currentVersion.compareTo(notSupportFromPortalVersion) >= 0) {
-				throw new ConfigurationException(
-					"War Core Ext project is only supported starting from portal 7.0 to 7.2", validationTitle);
-			}
-		}
-
 		ProjectManager projectManager = ProjectManager.getInstance();
 
 		Project workspaceProject = projectManager.getOpenProjects()[0];
@@ -243,6 +232,17 @@ public class LiferayProjectTypesComponent extends JPanel implements LiferayWorks
 			if (Objects.equals(type, "war-core-ext")) {
 				throw new ConfigurationException(
 					"Creating war-core-ext project with Maven is not supported", validationTitle);
+			}
+		}
+
+		if (type.equals("war-core-ext")) {
+			Version notSupportFromPortalVersion = new Version("7.3");
+
+			Version currentVersion = Version.parseVersion(_liferayVersion);
+
+			if (currentVersion.compareTo(notSupportFromPortalVersion) >= 0) {
+				throw new ConfigurationException(
+					"War Core Ext project is only supported starting from portal 7.0 to 7.2", validationTitle);
 			}
 		}
 

--- a/src/main/java/com/liferay/ide/idea/util/JavaUtil.java
+++ b/src/main/java/com/liferay/ide/idea/util/JavaUtil.java
@@ -92,4 +92,20 @@ public class JavaUtil {
 		return null;
 	}
 
+	public static boolean scanFolderJarsForManifestProp(
+		File location, String mainFolder, String property, String propPrefix) {
+
+		String value = getManifestPropFromFolderJars(location, mainFolder, property);
+
+		if (value != null) {
+			String trimedValue = value.trim();
+
+			if (trimedValue.startsWith(propPrefix)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 }

--- a/src/main/java/com/liferay/ide/idea/util/ServerUtil.java
+++ b/src/main/java/com/liferay/ide/idea/util/ServerUtil.java
@@ -23,6 +23,8 @@ import com.liferay.ide.idea.core.WorkspaceConstants;
 import com.liferay.ide.idea.server.LiferayDockerServerConfigurationType;
 import com.liferay.ide.idea.server.portal.PortalBundle;
 import com.liferay.ide.idea.server.portal.PortalBundleFactory;
+import com.liferay.ide.idea.server.portal.PortalJBossBundleFactory;
+import com.liferay.ide.idea.server.portal.PortalJBossEapBundleFactory;
 import com.liferay.ide.idea.server.portal.PortalTomcatBundleFactory;
 import com.liferay.ide.idea.server.portal.PortalWildFlyBundleFactory;
 
@@ -303,7 +305,8 @@ public class ServerUtil {
 	}
 
 	private static PortalBundleFactory[] _bundleFactories = {
-		new PortalTomcatBundleFactory(), new PortalWildFlyBundleFactory()
+		new PortalTomcatBundleFactory(), new PortalJBossBundleFactory(), new PortalJBossEapBundleFactory(),
+		new PortalWildFlyBundleFactory()
 	};
 	private static String[] _osgiBundleDirs = {"core", "modules", "portal", "static"};
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,6 +31,10 @@
 	</p>
 	<p>
 		<ul>
+			<li>2.0.1</li>
+			<ul>
+				<li>INTELLIJ-223 bug fix for starting tomcat using java 1.8</li>
+			</ul>
 			<li>2.0.0</li>
 			<ul>
 				<li>INTELLIJ-214 add validation when starting another server</li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,6 +31,14 @@
 	</p>
 	<p>
 		<ul>
+			<li>2.0.0</li>
+			<ul>
+				<li>INTELLIJ-214 add validation when starting another server</li>
+				<li>INTELLIJ-215 update default version to 74 on new maven workspace wizard</li>
+				<li>INTELLIJ-217 update to blade 4.0.10 release</li>
+				<li>INTELLIJ-219 add validation when creating war core ext project</li>
+				<li>INTELLIJ-220 upgrade sinceBuild to 213</li>
+			</ul>
 			<li>1.9.4</li>
 			<ul>
 				<li>INTELLIJ-203 improvements on new liferay module wizards</li>

--- a/src/test/java/com/liferay/ide/idea/language/tag/LiferayTaglibClassNameReferenceContributorTest.java
+++ b/src/test/java/com/liferay/ide/idea/language/tag/LiferayTaglibClassNameReferenceContributorTest.java
@@ -16,15 +16,15 @@ package com.liferay.ide.idea.language.tag;
 
 import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.LanguageLevelModuleExtension;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.pom.java.LanguageLevel;
+import com.intellij.testFramework.IdeaTestUtil;
 import com.intellij.testFramework.LightProjectDescriptor;
 import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor;
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase;
-
-import com.liferay.ide.idea.util.SdkUtil;
 
 import java.util.List;
 
@@ -42,6 +42,15 @@ public class LiferayTaglibClassNameReferenceContributorTest extends LightJavaCod
 		List<String> strings = myFixture.getLookupElementStrings();
 
 		assertTrue(strings.contains("MyObject"));
+	}
+
+	public void testCompletionInnerClass() {
+		myFixture.configureByFiles("inner.jsp", "liferay-aui.tld", "com/liferay/ide/model/MyOuter.java");
+		myFixture.complete(CompletionType.BASIC, 1);
+
+		List<String> strings = myFixture.getLookupElementStrings();
+
+		assertTrue("className attribute should suggest inner class \"MyInner\".", strings.contains("MyInner"));
 	}
 
 	@NotNull
@@ -68,8 +77,11 @@ public class LiferayTaglibClassNameReferenceContributorTest extends LightJavaCod
 			if (languageLevelModuleExtension != null) {
 				languageLevelModuleExtension.setLanguageLevel(LanguageLevel.JDK_1_8);
 			}
+		}
 
-			modifiableRootModel.setSdk(SdkUtil.getTestJdk());
+		@Override
+		public Sdk getSdk() {
+			return IdeaTestUtil.getMockJdk(LanguageLevel.JDK_1_8.toJavaVersion());
 		}
 
 	};

--- a/src/test/java/com/liferay/ide/idea/language/tag/LiferayTaglibSearchContainerJavaBeanReferenceContributorTest.java
+++ b/src/test/java/com/liferay/ide/idea/language/tag/LiferayTaglibSearchContainerJavaBeanReferenceContributorTest.java
@@ -16,6 +16,7 @@ package com.liferay.ide.idea.language.tag;
 
 import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.LanguageLevelModuleExtension;
@@ -64,6 +65,11 @@ public class LiferayTaglibSearchContainerJavaBeanReferenceContributorTest extend
 		public void configureModule(
 			@NotNull Module module, @NotNull ModifiableRootModel modifiableRootModel,
 			@NotNull ContentEntry contentEntry) {
+
+			ProjectJdkTable.getInstance(
+			).addJdk(
+				SdkUtil.getTestJdk()
+			);
 
 			LanguageLevelModuleExtension languageLevelModuleExtension = modifiableRootModel.getModuleExtension(
 				LanguageLevelModuleExtension.class);

--- a/testdata/com/liferay/ide/idea/language/tag/LiferayTaglibClassNameReferenceContributorTest/com/liferay/ide/model/MyOuter.java
+++ b/testdata/com/liferay/ide/idea/language/tag/LiferayTaglibClassNameReferenceContributorTest/com/liferay/ide/model/MyOuter.java
@@ -1,0 +1,8 @@
+package com.liferay.ide.model;
+
+public interface MyOuter {
+
+    interface MyInner {
+
+    }
+}

--- a/testdata/com/liferay/ide/idea/language/tag/LiferayTaglibClassNameReferenceContributorTest/inner.jsp
+++ b/testdata/com/liferay/ide/idea/language/tag/LiferayTaglibClassNameReferenceContributorTest/inner.jsp
@@ -1,0 +1,3 @@
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %>
+
+<aui:model-context model="com.liferay.ide.model.MyOuter.<caret>" />


### PR DESCRIPTION
check steps:
1.create gradle workspace 72
2.create maven workspace 72 in new window (window of gradle workspace 72 does not close)
3.open new module wizard
4.select war-core-ext as template and prepare project name
5.next

correct results:
module builds unsuccessful and idea hints "Creating war-core-ext project with Maven is not supported"
